### PR TITLE
Add YAML docs for example and math modules

### DIFF
--- a/docs/conf.yaml
+++ b/docs/conf.yaml
@@ -1,0 +1,23 @@
+DocsConfigModule: "Generates Sphinx documentation by invoking apitree on Gemma modules and colab notebooks."
+type: "Module"
+parameters_or_attributes:
+  _COLABS_NAMES: "List of colab notebook identifiers included in the generated docs."
+code_description: |
+  The module imports `apitree` and defines `_COLABS_NAMES` containing the names
+  of example notebooks. It then calls `apitree.make_project` with mappings for
+  Gemma modules and additional files to produce HTML documentation. The call
+  also registers redirections from simple page names to their corresponding
+  notebook pages and exposes variables from the current module to `apitree` via
+  `globals()`.
+relationships:
+  called_by:
+    - None
+  calls:
+    - apitree.make_project
+note: |
+  Run this script from the repository root after installing documentation
+  dependencies using `pip install -e .[docs]`. The output is written under
+  `docs/_build` when executed with `sphinx-build`.
+output_example: |
+  Running `sphinx-build -b html docs/ docs/_build` creates HTML files such as
+  `index.html` and converted colab notebooks like `colab_finetuning.html`.

--- a/examples/classification.yaml
+++ b/examples/classification.yaml
@@ -1,0 +1,54 @@
+get_config: "Creates a Trainer configuration for finetuning Gemma on a binary classification task."
+type: "Function"
+parameters_or_attributes:
+  None: "No parameters."
+code_description: |
+  `get_config` assembles and returns a `kd.train.Trainer` object configured for
+  binary text classification. It constructs the training dataset via
+  `_make_dataset(training=True)`, defines the Gemma model, loads a pretrained
+  checkpoint, specifies cross-entropy loss and an Adafactor optimizer, sets up a
+  checkpointer, and configures an evaluator for the test split.
+relationships:
+  called_by:
+    - kauldron.main when this config is referenced
+  calls:
+    - _make_dataset
+    - gm.nn.Gemma3_4B
+    - gm.ckpts.LoadCheckpoint
+    - kd.losses.SoftmaxCrossEntropyWithIntLabels
+    - optax.adafactor
+    - kd.ckpts.Checkpointer
+    - kd.evals.Evaluator
+note: |
+  This configuration assumes Kauldron and Gemma packages are installed. The
+  training dataset originates from the GLUE CoLA task and is tokenized using the
+  Gemma3Tokenizer.
+output_example: |
+  The returned `Trainer` can be executed with Kauldron's main runner to begin
+  finetuning, yielding logged metrics such as loss and accuracy every few steps.
+
+_make_dataset: "Builds the GLUE CoLA dataset pipeline for training or evaluation."
+type: "Function"
+parameters_or_attributes:
+  training: "Whether to prepare the training or validation split."
+code_description: |
+  `_make_dataset` constructs a `kd.data.py.Tfds` pipeline loading the GLUE CoLA
+  dataset. It decodes byte strings to text, formats input prompts, tokenizes and
+  pads sequences, maps integer labels to Yes/No tokens, and reshapes labels for
+  loss computation. The tokenizer used is `gm.text.Gemma3Tokenizer`.
+relationships:
+  called_by:
+    - get_config
+  calls:
+    - gm.data.DecodeBytes
+    - gm.data.FormatText
+    - gm.data.Tokenize
+    - gm.data.Pad
+    - gm.data.MapInts
+    - kd.data.Rearrange
+note: |
+  This pipeline expects the GLUE dataset to be available via TensorFlow Datasets
+  and is tailored for a small batch size of eight examples.
+output_example: |
+  Returns a `kd.data.py.Tfds` object yielding batches with keys `sentence` and
+  `label` transformed into token sequences and label tensors ready for training.

--- a/examples/dpo.yaml
+++ b/examples/dpo.yaml
@@ -1,0 +1,47 @@
+get_config: "Defines a Trainer setup for Direct Preference Optimization using Gemma."
+type: "Function"
+parameters_or_attributes:
+  None: "No parameters."
+code_description: |
+  `get_config` returns a `kd.train.Trainer` configured for preference-based
+  finetuning. The model is wrapped in `gm.nn.AnchoredPolicy` to combine a trainable
+  policy and a frozen reference model. It loads the pretrained checkpoint using
+  `gm.ckpts.AnchoredPolicyLoader` and applies a DPO loss during training. The
+  dataset is built via `_make_dataset(training=True)`.
+relationships:
+  called_by:
+    - kauldron.main when this configuration file is used
+  calls:
+    - _make_dataset
+    - gm.nn.AnchoredPolicy
+    - gm.ckpts.AnchoredPolicyLoader
+    - kd.losses.DpoLoss
+    - optax.adafactor
+    - kd.ckpts.Checkpointer
+note: |
+  This example expects the Argilla distilabel math preference dataset from
+  HuggingFace. Evaluation hooks are present but commented out.
+output_example: |
+  The generated Trainer trains the model to prefer chosen responses over
+  rejected ones, logging DPO loss values.
+
+_make_dataset: "Creates the HuggingFace dataset pipeline for DPO training."
+type: "Function"
+parameters_or_attributes:
+  training: "Whether to shuffle and repeat the dataset."
+code_description: |
+  The function builds a `kd.data.py.HuggingFace` pipeline that loads the
+  `argilla/distilabel-math-preference-dpo` dataset. It selects required fields
+  and applies `gm.data.ContrastiveTask` to produce tokenized inputs, target
+  sequences, and loss masks compatible with DPO training.
+relationships:
+  called_by:
+    - get_config
+  calls:
+    - gm.data.ContrastiveTask
+note: |
+  Maximum sequence length is fixed at 512 tokens, and the dataset batch size is
+  16 examples. Truncation may discard overly long entries.
+output_example: |
+  Returns a dataset pipeline yielding batches with `tokens`, `targets`, and `mask`
+  arrays for contrastive learning.

--- a/examples/lora.yaml
+++ b/examples/lora.yaml
@@ -1,0 +1,51 @@
+get_config: "Builds a Trainer configuration for LoRA-based Gemma finetuning."
+type: "Function"
+parameters_or_attributes:
+  None: "No parameters."
+code_description: |
+  `get_config` constructs a training configuration applying Low-Rank Adaptation
+  (LoRA) to the Gemma model. The model is wrapped in `gm.nn.LoRA` with rank 4
+  to insert trainable adapters. Initial weights are loaded via
+  `gm.ckpts.SkipLoRA` so only non-LoRA parameters are restored. The optimizer is
+  wrapped with `kd.optim.partial_updates` to update LoRA weights exclusively.
+relationships:
+  called_by:
+    - kauldron.main when using this example
+  calls:
+    - _make_dataset
+    - gm.nn.LoRA
+    - gm.ckpts.SkipLoRA
+    - kd.optim.partial_updates
+    - gm.evals.SamplerEvaluator
+note: |
+  The example builds on the sequence-to-sequence pipeline and limits maximum
+  length to 512 tokens. An additional evaluator samples model outputs on the
+  test set.
+output_example: |
+  The returned Trainer trains only the LoRA layers while leaving the base model
+  frozen and periodically generates example outputs.
+
+_make_dataset: "Creates the MTNT dataset pipeline used for training and evaluation."
+type: "Function"
+parameters_or_attributes:
+  training: "Boolean flag selecting train or test split."
+  sampling: "If true, prepares a pipeline for generation without batching."
+  batch_size: "Batch size when not sampling."
+  max_length: "Maximum token length for padding and truncation."
+code_description: |
+  This helper builds a `kd.data.py.Tfds` pipeline reading the MTNT dataset. It
+  uses `gm.data.Seq2SeqTask` to create inputs, targets, and loss masks and may
+  reduce batch size to `None` when sampling to generate example outputs.
+relationships:
+  called_by:
+    - get_config
+    - gm.evals.SamplerEvaluator
+  calls:
+    - gm.data.Seq2SeqTask
+    - kd.data.py.Tfds
+note: |
+  `max_length` applies only when not sampling. The dataset is shuffled and
+  repeated for training but iterates once for evaluation.
+output_example: |
+  Returns a dataset pipeline delivering batches with fields `input`, `target`,
+  and `loss_mask` for fine-tuning.

--- a/examples/multimodal.yaml
+++ b/examples/multimodal.yaml
@@ -1,0 +1,53 @@
+get_config: "Returns a Trainer configuration for image captioning with Gemma."
+type: "Function"
+parameters_or_attributes:
+  None: "No parameters."
+code_description: |
+  `get_config` sets up a multimodal training pipeline where images are paired
+  with caption text. It constructs the dataset via `_make_dataset`, configures
+  the Gemma3_4B model to accept both token and image inputs, applies a standard
+  cross-entropy loss, adds an image summary, and defines sampling evaluators for
+  periodic qualitative inspection.
+relationships:
+  called_by:
+    - kauldron.main when using this configuration
+  calls:
+    - _make_dataset
+    - gm.nn.Gemma3_4B
+    - kd.summaries.ShowImages
+    - gm.evals.SamplerEvaluator
+note: |
+  Images are resized to 800x800 pixels and cast to `uint8` before being fed to
+  the model. Training uses Adafactor with a learning rate of 1e-3.
+output_example: |
+  The produced Trainer trains on the ai2dcaption dataset and periodically logs
+  sampled predictions together with input images.
+
+_make_dataset: "Prepares the ai2dcaption dataset pipeline with image and text transformations."
+type: "Function"
+parameters_or_attributes:
+  training: "Whether to use the training or test split."
+  sampling: "Enable a sampling-friendly pipeline without batching."
+  batch_size: "Optional batch size when not sampling."
+  max_length: "Maximum token length for sequence padding."
+code_description: |
+  The dataset pipeline loads ai2dcaption via TensorFlow Datasets, keeps only the
+  image and caption fields, inserts a constant prompt token, applies
+  `gm.data.Seq2SeqTask` to produce model inputs and targets, resizes images, and
+  ensures they are in NHWC format.
+relationships:
+  called_by:
+    - get_config
+    - gm.evals.SamplerEvaluator
+  calls:
+    - kd.data.Elements
+    - gm.data.Seq2SeqTask
+    - kd.data.py.Resize
+    - kd.data.Rearrange
+    - kd.data.Cast
+note: |
+  When `sampling` is True, batch size is set to None and maximum length is not
+  enforced. Images are cast to unsigned 8-bit for compatibility with summaries.
+output_example: |
+  Returns a pipeline yielding dictionaries with `input`, `target`, `loss_mask`,
+  and processed `image` arrays.

--- a/examples/seq2seq.yaml
+++ b/examples/seq2seq.yaml
@@ -1,0 +1,50 @@
+get_config: "Creates a Trainer configuration for text-to-text finetuning."
+type: "Function"
+parameters_or_attributes:
+  None: "No parameters."
+code_description: |
+  `get_config` sets up a sequence-to-sequence training routine using the MTNT
+  dataset. It constructs the dataset through `_make_dataset`, loads the
+  pretrained Gemma checkpoint, applies cross-entropy loss, and configures an
+  evaluator along with a sampler to periodically generate translations.
+relationships:
+  called_by:
+    - kauldron.main when using this config
+  calls:
+    - _make_dataset
+    - gm.nn.Gemma3_4B
+    - gm.ckpts.LoadCheckpoint
+    - kd.losses.SoftmaxCrossEntropyWithIntLabels
+    - optax.adafactor
+    - kd.ckpts.Checkpointer
+    - gm.evals.SamplerEvaluator
+note: |
+  This example trains with a batch size of 32 and sequence length capped at
+  512 tokens. Sampling evaluators generate example translations during training.
+output_example: |
+  The returned Trainer can be run via `kauldron.main` to finetune the model on
+  the MTNT English-French dataset.
+
+_make_dataset: "Constructs the MTNT dataset pipeline for prompting and response generation."
+type: "Function"
+parameters_or_attributes:
+  training: "Selects the dataset split and whether to shuffle." 
+  sampling: "If true, returns a pipeline suited for inference sampling." 
+  batch_size: "Batch size for training or evaluation." 
+  max_length: "Maximum sequence length for padding and truncation." 
+code_description: |
+  The function builds a `kd.data.py.Tfds` pipeline reading MTNT, then uses
+  `gm.data.Seq2SeqTask` to produce tokenized inputs, target sequences, and loss
+  masks. When `sampling` is True, batch size becomes None allowing inference on
+  a single example.
+relationships:
+  called_by:
+    - get_config
+    - gm.evals.SamplerEvaluator
+  calls:
+    - gm.data.Seq2SeqTask
+note: |
+  Approximately 1% of dataset examples exceed 512 tokens and will be truncated.
+output_example: |
+  Returns a pipeline yielding dictionaries with keys `input`, `target`, and
+  `loss_mask` for training or evaluation.

--- a/examples/sharding.yaml
+++ b/examples/sharding.yaml
@@ -1,0 +1,49 @@
+get_config: "Defines a Trainer setup for sequence-to-sequence training with parameter sharding."
+type: "Function"
+parameters_or_attributes:
+  None: "No parameters."
+code_description: |
+  Similar to the basic seq2seq example, `get_config` prepares training on the
+  MTNT dataset but enables distributed parameter sharding via
+  `kd.sharding.ShardingStrategy` with FSDP. The rest of the Trainer mirrors the
+  sequence-to-sequence setup.
+relationships:
+  called_by:
+    - kauldron.main when executing this file
+  calls:
+    - _make_dataset
+    - gm.nn.Gemma3_4B
+    - kd.sharding.ShardingStrategy
+    - gm.ckpts.LoadCheckpoint
+    - kd.losses.SoftmaxCrossEntropyWithIntLabels
+    - optax.adafactor
+note: |
+  Use this example when training on multiple devices requiring parameter
+  sharding. The dataset and loss configuration remain the same as `seq2seq.py`.
+output_example: |
+  Running the Trainer distributes the model parameters across devices with FSDP
+  while training on the MTNT dataset.
+
+_make_dataset: "Generates the MTNT dataset pipeline used in the sharded training example."
+type: "Function"
+parameters_or_attributes:
+  training: "Determines split and shuffle." 
+  sampling: "Prepares a sampling-only pipeline." 
+  batch_size: "Optional batch size for training." 
+  max_length: "Max token length used for padding." 
+code_description: |
+  This helper is identical to the one from `seq2seq.py`. It loads MTNT using
+  TensorFlow Datasets and applies `gm.data.Seq2SeqTask` to produce model-ready
+  batches. When sampling, batch size is set to None.
+relationships:
+  called_by:
+    - get_config
+    - gm.evals.SamplerEvaluator
+  calls:
+    - gm.data.Seq2SeqTask
+note: |
+  Examples longer than 512 tokens are truncated. Shuffle is enabled only during
+  training.
+output_example: |
+  Returns a dataset pipeline providing `input`, `target`, and `loss_mask` fields
+  for the Trainer.

--- a/gemma/gm/math/__init__.yaml
+++ b/gemma/gm/math/__init__.yaml
@@ -1,0 +1,19 @@
+module_summary: "Exposes math utilities such as apply_rope for positional embeddings."
+type: "Module"
+parameters_or_attributes:
+  apply_rope: "Imported function from _positional_embeddings for public use."
+code_description: |
+  The `gemma.gm.math` package initialization file re-exports the
+  `apply_rope` function, enabling consumers to import it directly from
+  `gemma.gm.math`. Additional utilities may be added in this namespace.
+relationships:
+  called_by:
+    - External modules importing `gemma.gm.math.apply_rope`
+  calls:
+    - gemma.gm.math._positional_embeddings.apply_rope
+note: |
+  This module currently only exposes positional embedding helpers but serves as
+  a central location for future math utilities.
+output_example: |
+  Users can call `from gemma.gm import math; math.apply_rope(...)` to apply
+  rotary embeddings.

--- a/gemma/gm/math/_pos_utils.yaml
+++ b/gemma/gm/math/_pos_utils.yaml
@@ -1,0 +1,19 @@
+build_positions_from_mask: "Computes position indices for token sequences based on an input mask."
+type: "Function"
+parameters_or_attributes:
+  input_mask: "Boolean array indicating valid (non-padded) token positions."
+code_description: |
+  The function calculates cumulative sums over the `input_mask` to determine
+  absolute positions for tokens. It subtracts one from positions after the first
+  valid token so indexing starts at zero. Padded positions yield arbitrary values
+  but are typically ignored by later computations such as RoPE.
+relationships:
+  called_by:
+    - gemma.gm.math modules requiring positional indices
+  calls:
+    - jax.numpy.cumsum
+note: |
+  `input_mask` must be a JAX array where non-zero entries correspond to real
+  tokens. The returned array matches the input shape.
+output_example: |
+  Passing `jnp.array([[1,1,0]])` returns `jnp.array([[0,1,0]])`.

--- a/gemma/gm/math/_positional_embeddings.yaml
+++ b/gemma/gm/math/_positional_embeddings.yaml
@@ -1,0 +1,27 @@
+apply_rope: "Applies Rotary Positional Embedding transformations to input tensors."
+type: "Function"
+parameters_or_attributes:
+  inputs: "Tensor of shape [B, L, N, H] containing query/key embeddings."
+  positions: "Tensor of shape [B, L] with absolute position indices."
+  base_frequency: "Base frequency controlling sinusoid wavelengths."
+  scale_factor: "Optional scaling factor for position interpolation."
+code_description: |
+  `apply_rope` splits the last dimension of `inputs` into pairs and rotates them
+  according to sinusoidal functions determined by `positions`. It computes a
+  timescale based on `base_frequency` and optionally scales positions to allow
+  extended context lengths. The concatenated rotated halves are returned in the
+  original data type.
+relationships:
+  called_by:
+    - gemma.gm.math modules applying rotary embeddings
+    - gemma.gm.math._positional_embeddings_test.test_rope_positional_embeddings
+  calls:
+    - jax.numpy.sin
+    - jax.numpy.cos
+    - jax.numpy.concatenate
+note: |
+  The head dimension must be even. A ValueError is raised if `scale_factor` is
+  less than 1.0.
+output_example: |
+  Given ones with shape [2,1,2,4] and positions [[1],[0]], the function returns
+  rotated embeddings similar to those asserted in the test module.

--- a/gemma/gm/math/_positional_embeddings_test.yaml
+++ b/gemma/gm/math/_positional_embeddings_test.yaml
@@ -1,0 +1,23 @@
+test_rope_positional_embeddings: "Verifies the apply_rope function against expected outputs."
+type: "Function"
+parameters_or_attributes:
+  input_embedding_shape: "Shape of the input tensor under test."
+  positions: "Position indices passed to apply_rope."
+  max_wavelength: "Maximum wavelength parameter for rotary embeddings."
+  expected: "Expected numeric output array."
+code_description: |
+  The test constructs an input tensor of ones, applies `gm.math.apply_rope` with
+  the provided parameters, and asserts that the resulting array matches the
+  expected values using NumPy's test utilities.
+relationships:
+  called_by:
+    - pytest during unit testing
+  calls:
+    - gm.math.apply_rope
+    - numpy.testing.assert_array_almost_equal
+note: |
+  This test is parametrized to allow multiple scenarios, although only one case
+  is presently defined.
+output_example: |
+  When executed, pytest reports success if the rotated embeddings align with the
+  expected array.


### PR DESCRIPTION
## Summary
- add documentation YAML for docs/conf module
- add YAML docs for example configs
- add YAML docs for math utilities

## Testing
- `pytest -q` *(fails: ImportError while importing test module)*

------
https://chatgpt.com/codex/tasks/task_e_686f3d8fc0cc832faf9dbbba79961ffe